### PR TITLE
fix: unify button pin usage

### DIFF
--- a/timinoo/timinoo.ino
+++ b/timinoo/timinoo.ino
@@ -31,7 +31,6 @@ Y Pos for lines: 8 / 21 / 34 / 47 / 60
 int gameMode = 99;
 char scoreString[9];
 const char* textToDisplay = "";
-const int buttonPin = 2;
 int buttonState = 0;
 unsigned long frameCounter = 0;
 int animationStep = 1;
@@ -758,7 +757,7 @@ void checkButton()
 void setup(void) {
   // initialize the pushbutton pin as an input:
   u8g.begin();
-  pinMode(buttonPin, INPUT);
+  pinMode(ButtonPin, INPUT);
   // Better random numbers
   randomSeed(analogRead(A0));
   // Wait a bit


### PR DESCRIPTION
## Summary
- rely on a single `ButtonPin` constant in the main sketch to avoid mismatched button configuration

## Testing
- `g++ -x c++ timinoo/timinoo.ino -c` *(fails: U8g2lib.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689eeeb85d8c83219806ea83ee5a0b87