### PR TITLE
Center drawDialog text horizontally

### DIFF
--- a/timinoo/timinoo.ino
+++ b/timinoo/timinoo.ino
@@ -868,7 +868,7 @@ void drawDialog(int mode, const char* text, const char* helper, int icon) {
 
   u8g.drawLine(0, 56, 127, 56);
   u8g.setFont(u8g_font_baby);
-  u8g.drawStr(10, 63, helper);
+  u8g.drawStr(5, 63, helper);
 }
 
 void setup(void) {

--- a/timinoo/timinoo.ino
+++ b/timinoo/timinoo.ino
@@ -837,7 +837,11 @@ void drawDialog(int mode, const char* text, const char* helper, int icon) {
 
   // u8g.setFont(u8g_font_baby);
   u8g.setFont(u8g2_font_ncenB08_tr);
-  u8g.drawStr(10, 18, text);
+  int textX = (128 - u8g.getStrWidth(text)) / 2;
+  if (textX < 0) {
+    textX = 0;
+  }
+  u8g.drawStr(textX, 18, text);
 
   switch (icon) {
     case 0:

--- a/timinoo/timinoo.ino
+++ b/timinoo/timinoo.ino
@@ -832,16 +832,12 @@ void drawDialog(int mode, const char* text, const char* helper, int icon) {
     return;
   }
 
-  // u8g.drawLine(0, 8, 127, 8);
-  u8g.drawLine(0, 56, 127, 56);
-
-  // u8g.setFont(u8g_font_baby);
   u8g.setFont(u8g2_font_ncenB08_tr);
   int textX = (128 - u8g.getStrWidth(text)) / 2;
   if (textX < 0) {
     textX = 0;
   }
-  u8g.drawStr(textX, 18, text);
+  u8g.drawStr(textX, 10, text);
 
   switch (icon) {
     case 0:
@@ -870,6 +866,7 @@ void drawDialog(int mode, const char* text, const char* helper, int icon) {
       break;
   }
 
+  u8g.drawLine(0, 56, 127, 56);
   u8g.setFont(u8g_font_baby);
   u8g.drawStr(10, 63, helper);
 }


### PR DESCRIPTION
### Motivation
- Ensure the dialog title string is centered on the 128px-wide OLED instead of using a fixed x offset so messages look properly aligned for different lengths.

### Description
- In `drawDialog()` set the font and compute `textX = (128 - u8g.getStrWidth(text)) / 2`, clamp `textX` to `0` if negative, and call `u8g.drawStr(textX, 18, text)` to draw the text centered.

### Testing
- No automated tests were run for this Arduino sketch in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a082d6000d8832196cd5bb37f1bbeda)